### PR TITLE
Use cors_allowed_origins in AsyncServer

### DIFF
--- a/fastapi_socketio/socket_manager.py
+++ b/fastapi_socketio/socket_manager.py
@@ -1,4 +1,5 @@
 import socketio
+from typing import Union
 from fastapi import FastAPI
 
 
@@ -21,10 +22,10 @@ class SocketManager:
         app: FastAPI,
         mount_location: str = "/ws",
         socketio_path: str = "socket.io",
-        cors_allowed_origins: list = [],
+        cors_allowed_origins: Union[str, list] = '*',
     ) -> None:
         # TODO: Change Cors policy based on fastapi cors Middleware
-        self._sio = socketio.AsyncServer(async_mode="asgi", cors_allowed_origins="*")
+        self._sio = socketio.AsyncServer(async_mode="asgi", cors_allowed_origins=cors_allowed_origins)
         self._app = socketio.ASGIApp(
             socketio_server=self._sio, socketio_path=socketio_path
         )


### PR DESCRIPTION
I needed CORS on my entire app, so I used `app.add_middleware(CORSMiddleware, ...)` with a specific origin. This broke websockets because it caused duplicate headers for requests to `/ws/*`:
```
access-control-allow-origin: http://localhost:3000
access-control-allow-credentials: true
access-control-allow-credentials: true
access-control-allow-origin: http://localhost:3000
```
(For some reason this messed up Firefox's CORS verification) So, I tried to explicitly disabling it with `cors_allowed_origins=[]`, but I realized the parameter wasn't being used. This PR fixes that. Note that I changed the default parameter to `"*"` so that the behavior would remain unchanged.